### PR TITLE
Add scripts to allow for constructing local-only docker images with a single connector

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,0 +1,13 @@
+ARG TAG
+ARG CP_CONNECT_IMAGE
+FROM confluentinc/${CP_CONNECT_IMAGE}:${TAG}
+ARG TAG
+ARG TAG_BASE
+ARG CONNECTOR
+USER root
+RUN yum -y install bind-utils openssl unzip findutils net-tools nc jq which iptables || true && exit 0
+RUN apt-get update; apt-get -y install bind-utils openssl unzip findutils net-tools nc jq which iptables || true && exit 0
+COPY jmx_prometheus_javaagent-0.12.0.jar /usr/share/
+COPY kafka-connect-couchbase-3.4.8 /usr/share/confluent-hub-components/kafka-connect-couchbase
+COPY ${CONNECTOR} /tmp
+RUN confluent-hub install --no-prompt /tmp/${CONNECTOR}

--- a/scripts/create-image-local.sh
+++ b/scripts/create-image-local.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -e
+
+function log() {
+  YELLOW='\033[0;33m'
+  NC='\033[0m' # No Color
+  echo -e "$YELLOW$@$NC"
+}
+
+function logerror() {
+  RED='\033[0;31m'
+  NC='\033[0m' # No Color
+  echo -e "$RED$@$NC"
+}
+
+function logwarn() {
+  PURPLE='\033[0;35m'
+  NC='\033[0m' # No Color
+  echo -e "$PURPLE$@$NC"
+}
+
+function retry() {
+  local n=1
+  local max=5
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        logwarn "Command failed. Attempt $n/$max:"
+      else
+        logerror "The command has failed after $n attempts."
+        return 1
+      fi
+    }
+  done
+}
+
+# https://stackoverflow.com/a/24067243
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+
+# jmx exporter java agent
+wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.12.0/jmx_prometheus_javaagent-0.12.0.jar
+
+# specific to couchbase connector
+wget https://packages.couchbase.com/clients/kafka/3.4.8/kafka-connect-couchbase-3.4.8.zip
+unzip kafka-connect-couchbase-3.4.8.zip
+
+path_to_local_connector=$1
+shift
+cp $path_to_local_connector .
+export CONNECTOR=$(basename -- "$path_to_local_connector")
+
+for version in $@
+do
+  export TAG=${version}
+  # to handle ubi8 images
+  export TAG_BASE=$(echo $TAG | cut -d "-" -f1)
+
+  first_version=${TAG_BASE}
+  second_version=5.3.0
+  if version_gt $first_version $second_version; then
+      export CP_CONNECT_IMAGE=cp-server-connect-base
+  else
+      export CP_CONNECT_IMAGE=cp-kafka-connect-base
+  fi
+
+  retry docker build -f Dockerfile-local \
+      --build-arg TAG=$TAG \
+      --build-arg CONNECTOR=$CONNECTOR \
+      --build-arg CP_CONNECT_IMAGE=$CP_CONNECT_IMAGE \
+      --build-arg TAG_BASE=$TAG_BASE \
+      -t vdesabou/kafka-docker-playground-connect:$TAG .
+
+done
+
+rm -rf kafka-connect-couchbase-3.4.8 kafka-connect-couchbase-3.4.8.zip jmx_prometheus_javaagent-0.12.0.jar $CONNECTOR


### PR DESCRIPTION
Usage example to build a local image with a single, locally built connector for testing:
```
./scripts/create-image-local.sh ~/prod/kafka-connect-jira/target/components/packages/confluentinc-kafka-connect-jira-1.0.4-SNAPSHOT-preview.zip 6.1.0
```